### PR TITLE
extract slice as slice

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -69,7 +69,7 @@ sudo nala update
 sudo nala install brave-browser -y
 
 # Enable graphical login and change target from CLI to GUI
-tar -xzvf slice.tar.gz -C /usr/share/sddm/themes
+tar -xzvf slice.tar.gz --strip 1 --one-top-level=/usr/share/sddm/themes/slice
 cp -f "$builddir/sddm.conf" /etc/
 systemctl enable sddm
 systemctl set-default graphical.target


### PR DESCRIPTION
`sddm.conf` includes the following:
```
[Theme]
Current=slice
```
but slice is extracted to `/usr/share/sddm/themes/` as `sddm-slice-<version>` and now it'll extract slice as `slice`. Otherwise slice theme is not applied.