### PR TITLE
Change default ethernet interface to new one

### DIFF
--- a/scripts/changeinterface
+++ b/scripts/changeinterface
@@ -8,7 +8,7 @@ if [ -z "$if" ];then # is interface empty?
         # If there is no eth interface, do not do anything.
         exit
 fi
-defif="eth0"  # default eth interface in polybar config
+defif="enp89s0"  # default eth interface in polybar config
 sed -i "s/$defif/$if/g" "$config" # change default eth interface to yours
 }
 wlan() {

--- a/scripts/changeinterface
+++ b/scripts/changeinterface
@@ -1,5 +1,6 @@
 #!/bin/bash
 username=$(id -u -n 1000)
+
 changeinterface() {
 config="/home/$username/.config/polybar/config.ini" # Define polybar config file
 eth() {
@@ -8,7 +9,9 @@ if [ -z "$if" ];then # is interface empty?
         # If there is no eth interface, do not do anything.
         exit
 fi
-defif="enp89s0"  # default eth interface in polybar config
+# Automatically take default interface in the config
+grabinterfaces="$(cat $config | grep '^interface =')" # Grab all interfaces in the config
+defif="$(echo $grabinterfaces | awk '{print $3}')" # Take default eth interface in the config
 sed -i "s/$defif/$if/g" "$config" # change default eth interface to yours
 }
 wlan() {
@@ -17,7 +20,8 @@ if [ -z "$if" ];then # is interface empty?
         # If there is no wlan interface, do not do anything.
         exit
 fi
-defif="wlan0"  # default wlan interface in polybar config
+grabinterfaces="$(cat $config |	grep '^interface =')" # Grab all interfaces in the config
+defif="$(echo $grabinterfaces | awk '{print $6}')" # Take default wlan interface in the config
 sed -i "s/$defif/$if/g" "$config" # change default wlan interface to yours
 }
 # Run functions


### PR DESCRIPTION
I noticed polybar's default `eth` interface isn't `eth0` anymore, I changed default eth interface in the script to new interface. The `changeinterface` script didn't work because it couldn't find `eth0` interface in the config to change with user's interface.

### Before
![image](https://user-images.githubusercontent.com/61632416/208474816-8a91c9ab-5b44-4163-8ceb-81423e384615.png)
### After
![image](https://user-images.githubusercontent.com/61632416/208474916-e6397c5b-8035-4f55-b77a-1d26106f3968.png)
